### PR TITLE
fixed meta path

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -7,13 +7,13 @@ jobs:
     main:
         steps:
             - print: echo Starting main job!
-            - set_meta: meta set "foo" "foobar"
+            - set_meta: /opt/sd/meta set "foo" "foobar"
     second:
         steps:
             - print: echo Starting second job!
-            - check_meta: test "foobar" `meta get "foo"`
-            - set_meta: meta set "bar" "barbaz"
+            - check_meta: test "foobar" = `meta get "foo"`
+            - set_meta: /opt/sd/meta set "bar" "barbaz"
     third:
         steps:
             - print: echo Starting third job!
-            - check_meta: test "barbaz" `meta get "bar"`
+            - check_meta: test "barbaz" = `meta get "bar"`

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -7,13 +7,13 @@ jobs:
     main:
         steps:
             - print: echo Starting main job!
-            - set_meta: /opt/sd/meta set "foo" "foobar"
+            - set_meta: meta set "foo" "foobar"
     second:
         steps:
             - print: echo Starting second job!
-            - check_meta: test "foobar" = `/opt/sd/meta get "foo"`
-            - set_meta: /opt/sd/meta set "bar" "barbaz"
+            - check_meta: test "foobar" = `meta get "foo"`
+            - set_meta: meta set "bar" "barbaz"
     third:
         steps:
             - print: echo Starting third job!
-            - check_meta: test "barbaz" = `/opt/sd/meta get "bar"`
+            - check_meta: test "barbaz" = `meta get "bar"`

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -11,9 +11,9 @@ jobs:
     second:
         steps:
             - print: echo Starting second job!
-            - check_meta: test "foobar" = `meta get "foo"`
+            - check_meta: test "foobar" = `/opt/sd/meta get "foo"`
             - set_meta: /opt/sd/meta set "bar" "barbaz"
     third:
         steps:
             - print: echo Starting third job!
-            - check_meta: test "barbaz" = `meta get "bar"`
+            - check_meta: test "barbaz" = `/opt/sd/meta get "bar"`


### PR DESCRIPTION
bug fix ~~and explicitly specify the PATH of `meta` because for now, it is still necessary to specify `LAUNCH_VERSION: v4.0.12` in the `docker-compose.yml`. It corrects to the state where it operates even if not set environments of `/opt/sd`.~~
